### PR TITLE
Generate code coverage when running unit tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,5 @@ before_script:
 script:
   - npm run showconfig
   - npm run test
+after_success:
+  - npm run coverage

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Swarm City API accelerator
 
 [![Build Status](https://travis-ci.org/swarmcity/SwarmCityAPI.svg?branch=master)](https://travis-ci.org/swarmcity/SwarmCityAPI)
-
 [![Coverage Status](https://coveralls.io/repos/github/swarmcity/SwarmCityAPI/badge.svg)](https://coveralls.io/github/swarmcity/SwarmCityAPI)
 
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Swarm City API accelerator
 
+[![Build Status](https://travis-ci.org/swarmcity/SwarmCityAPI.svg?branch=master)](https://travis-ci.org/swarmcity/SwarmCityAPI)
 
 [![Coverage Status](https://coveralls.io/repos/github/swarmcity/SwarmCityAPI/badge.svg)](https://coveralls.io/github/swarmcity/SwarmCityAPI)
-
-[![Build Status](https://travis-ci.org/swarmcity/SwarmCityAPI.svg?branch=master)](https://travis-ci.org/swarmcity/SwarmCityAPI)
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Swarm City API accelerator
 
+[![Coverage Status](https://coveralls.io/repos/github/swarmcity/SwarmCityAPI/badge.svg)](https://coveralls.io/github/swarmcity/SwarmCityAPI)
 
 # Usage
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "socket.js",
   "scripts": {
-    "test": "mocha --exit --timeout 180000 test/*",
+    "test": "nyc mocha --exit --timeout 180000 test/*",
     "lint": "eslint .",
     "esw": "esw .",
     "showconfig": "node showEnv.js"
@@ -31,6 +31,7 @@
     "eslint": "^4.10.0",
     "eslint-config-google": "^0.9.1",
     "mocha": "^4.0.1",
+    "nyc": "^11.3.0",
     "should": "^13.1.3",
     "socketio-wildcard": "^2.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "socket.js",
   "scripts": {
     "test": "nyc mocha --exit --timeout 180000 test/*",
+    "coverage": "nyc report --reporter=text-lcov | coveralls",
     "lint": "eslint .",
     "esw": "esw .",
     "showconfig": "node showEnv.js"
@@ -28,6 +29,7 @@
     "winston": "^3.0.0-rc1"
   },
   "devDependencies": {
+    "coveralls": "^3.0.0",
     "eslint": "^4.10.0",
     "eslint-config-google": "^0.9.1",
     "mocha": "^4.0.1",


### PR DESCRIPTION
Shows what parts of your code are covered by unit tests and what parts aren't.

Currently this is being generated every time you run `npm run test`. If this is too much noise, I can change it so it only runs with a separate command, eg. `npm run test-with-coverage`.

Optionally, you can also add coveralls support so you get realtime updates on code coverage stats with every pull request.