### PR TITLE
Reduce IPFS concurrency

### DIFF
--- a/src/scheduler/IPFSQueue.js
+++ b/src/scheduler/IPFSQueue.js
@@ -32,7 +32,7 @@ let q = queue((task, callback) => {
 			);
 			callback(null, task);
 		});
-}, 20);
+}, 8);
 
 module.exports = () => {
 	return (q);

--- a/src/scheduler/IPFSQueueLight.js
+++ b/src/scheduler/IPFSQueueLight.js
@@ -3,7 +3,7 @@ const {promisify} = require('util');
 
 const maxAttempts = 3;
 const pauseTime = 300;
-const concurrency = 20;
+const concurrency = 4;
 
 const ipfsService = require('../services').ipfsService;
 


### PR DESCRIPTION
The IPFS was unable to resolve working hashes. Reducing the concurrency mitigates the risk for this type of problems.